### PR TITLE
New Api of 'SDWebImage' linkage bug handled

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Pod/Classes/MWPhoto.m
+++ b/Pod/Classes/MWPhoto.m
@@ -211,24 +211,26 @@
 - (void)_performLoadUnderlyingImageAndNotifyWithWebURL:(NSURL *)url {
     @try {
         SDWebImageManager *manager = [SDWebImageManager sharedManager];
-        _webImageOperation = [manager loadImageWithURL:url options:0 progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
-            if (expectedSize > 0) {
-                float progress = receivedSize / (float)expectedSize;
-                NSDictionary* dict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                      [NSNumber numberWithFloat:progress], @"progress",
-                                      self, @"photo", nil];
-                [[NSNotificationCenter defaultCenter] postNotificationName:MWPHOTO_PROGRESS_NOTIFICATION object:dict];
-            }
-        } completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
-            if (error) {
-                MWLog(@"SDWebImage failed to download image: %@", error);
-            }
-            _webImageOperation = nil;
-            self.underlyingImage = image;
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [self imageLoadingComplete];
-            });
-        }];
+        _webImageOperation = [manager downloadImageWithURL:url
+                                                   options:0
+                                                  progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                                      if (expectedSize > 0) {
+                                                          float progress = receivedSize / (float)expectedSize;
+                                                          NSDictionary* dict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                                                                [NSNumber numberWithFloat:progress], @"progress",
+                                                                                self, @"photo", nil];
+                                                          [[NSNotificationCenter defaultCenter] postNotificationName:MWPHOTO_PROGRESS_NOTIFICATION object:dict];
+                                                      }
+                                                  } completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+                                                      if (error) {
+                                                          MWLog(@"SDWebImage failed to download image: %@", error);
+                                                      }
+                                                      _webImageOperation = nil;
+                                                      self.underlyingImage = image;
+                                                      dispatch_async(dispatch_get_main_queue(), ^{
+                                                          [self imageLoadingComplete];
+                                                      });
+                                                  }];
     } @catch (NSException *e) {
         MWLog(@"Photo from web: %@", e);
         _webImageOperation = nil;

--- a/Pod/Classes/MWPhotoBrowser.m
+++ b/Pod/Classes/MWPhotoBrowser.m
@@ -12,7 +12,7 @@
 #import "MWPhotoBrowserPrivate.h"
 #import "SDImageCache.h"
 #import "UIImage+MWPhotoBrowser.h"
-#import <XCDYouTubeKit.h>
+#import "XCDYouTubeKit.h"
 
 #define PADDING                  10
 


### PR DESCRIPTION
MWPhotoBrowser was not loading the video because it used SDWebImage to load the video's thumbnail. But in the current version of MWPhotoBrowser, it was calling the old interface of the SDWebImage which was now deprecated. So I just changed its interface without migrating the whole library to the new version.